### PR TITLE
Feat: User Create API

### DIFF
--- a/src/main/java/intership/test/domain/user/controller/UserController.java
+++ b/src/main/java/intership/test/domain/user/controller/UserController.java
@@ -1,23 +1,45 @@
 package intership.test.domain.user.controller;
 
+import intership.test.domain.user.dto.UserCreate;
+import intership.test.domain.user.dto.UserMapper;
+import intership.test.domain.user.entity.User;
+import intership.test.domain.user.exception.InformationMissing;
 import intership.test.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.http.HttpResponse;
 
 @RestController
 @RequestMapping(value = "/users")
 @RequiredArgsConstructor
+@Slf4j
 public class UserController {
 
     private final UserService userService;
+
+    @PostMapping("/")
+    public ResponseEntity<String> createUser(@Validated UserCreate userCreate, BindingResult bindingResult){
+
+        if(bindingResult.hasErrors()){
+            StringBuilder errorMsg = new StringBuilder();
+            bindingResult.getFieldErrors().forEach(error -> {
+                errorMsg.append(error.getField()).append(": ").append(error.getDefaultMessage()).append("\n");
+            });
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMsg.toString());
+        }
+
+        userService.createUser(userCreate);
+        return ResponseEntity.ok("유저 생성을 완료하였습니다.");
+    }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteUser(
@@ -26,6 +48,4 @@ public class UserController {
         userService.deleteUser(id);
         return ResponseEntity.ok("유저 삭제를 완료하였습니다.");
     }
-//    @PostMapping("/")
-//    public
 }

--- a/src/main/java/intership/test/domain/user/dto/UserCreate.java
+++ b/src/main/java/intership/test/domain/user/dto/UserCreate.java
@@ -1,0 +1,30 @@
+package intership.test.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserCreate {
+    @NotNull(message = "아이디를 입력하지 않았습니다.")
+    private Long id;
+
+    @NotBlank(message = "이름을 입력하지 않았습니다.")
+    private String name;
+
+    @NotNull(message = "나이를 입력하지 않았습니다.")
+    private Integer age;
+
+    @Builder
+    public UserCreate(Long id, String name, Integer age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+
+}

--- a/src/main/java/intership/test/domain/user/dto/UserMapper.java
+++ b/src/main/java/intership/test/domain/user/dto/UserMapper.java
@@ -1,0 +1,26 @@
+package intership.test.domain.user.dto;
+
+import intership.test.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserMapper {
+    public static User toUser(UserCreate userCreate){
+        return User
+                .builder()
+                .id(userCreate.getId())
+                .name(userCreate.getName())
+                .age(userCreate.getAge())
+                .build();
+    }
+
+    public static UserCreate toUserCreate(User user){
+        return UserCreate
+                .builder()
+                .id(user.getId())
+                .name(user.getName())
+                .age(user.getAge())
+                .build();
+    }
+}

--- a/src/main/java/intership/test/domain/user/entity/User.java
+++ b/src/main/java/intership/test/domain/user/entity/User.java
@@ -13,8 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     @Id
@@ -23,7 +22,7 @@ public class User {
 
     private String name;
 
-    private int age;
+    private Integer age;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
@@ -41,4 +40,16 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Comment> comments;
+
+    @Builder
+    public User(Long id, String name, Integer age, Date createdAt, Date modifiedAt, List<Likes> likes, List<Board> boards, List<Comment> comments) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.likes = likes;
+        this.boards = boards;
+        this.comments = comments;
+    }
 }

--- a/src/main/java/intership/test/domain/user/exception/InformationMissing.java
+++ b/src/main/java/intership/test/domain/user/exception/InformationMissing.java
@@ -1,0 +1,10 @@
+package intership.test.domain.user.exception;
+
+import intership.test.exception.CustomException;
+import intership.test.exception.ErrorCode;
+
+public class InformationMissing extends CustomException {
+    public InformationMissing(ErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/intership/test/domain/user/exception/UserAlreadExist.java
+++ b/src/main/java/intership/test/domain/user/exception/UserAlreadExist.java
@@ -1,0 +1,10 @@
+package intership.test.domain.user.exception;
+
+import intership.test.exception.CustomException;
+import intership.test.exception.ErrorCode;
+
+public class UserAlreadExist extends CustomException {
+    public UserAlreadExist(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/intership/test/domain/user/service/UserService.java
+++ b/src/main/java/intership/test/domain/user/service/UserService.java
@@ -1,6 +1,9 @@
 package intership.test.domain.user.service;
 
+import intership.test.domain.user.dto.UserCreate;
+import intership.test.domain.user.dto.UserMapper;
 import intership.test.domain.user.entity.User;
+import intership.test.domain.user.exception.UserAlreadExist;
 import intership.test.domain.user.exception.UserNotFound;
 import intership.test.domain.user.repository.UserRepository;
 import intership.test.exception.ErrorCode;
@@ -8,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -17,6 +22,18 @@ public class UserService {
     private final UserRepository userRepository;
 
     //C
+    @Transactional
+    public void createUser(UserCreate userCreate){
+        Optional<User> exist = userRepository.findById(userCreate.getId());
+
+        if(!exist.isEmpty()){
+            throw new UserAlreadExist(ErrorCode.USER_ALREADY_EXIST);
+        }
+
+        userRepository.save(UserMapper.toUser(userCreate));
+
+        log.info("생성된 유저 : {}", userCreate.getId());
+    }
 
     //R
 
@@ -29,6 +46,6 @@ public class UserService {
 
         userRepository.deleteById(id);
 
-        log.info("삭제된 유저 : {}", user.toString());
+        log.info("삭제된 유저 : {}", user.getId());
     }
 }

--- a/src/main/java/intership/test/exception/ErrorCode.java
+++ b/src/main/java/intership/test/exception/ErrorCode.java
@@ -10,7 +10,9 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @Slf4j
 public enum ErrorCode {
     //User
-    USER_NOT_FOUND(BAD_REQUEST, "존재하지 않는 유저입니다, id를 다시 한 번 확인해주세요");
+    USER_NOT_FOUND(BAD_REQUEST, "존재하지 않는 유저입니다, id를 다시 한 번 확인해주세요"),
+    USER_ALREADY_EXIST(BAD_REQUEST, "이미 사용중인 아이디 입니다, 다른 아이디로 시도해주세요"),
+    REQUIRED_INFORMATION_MISSING(BAD_REQUEST, "필수 입력값이 입력되지 않았습니다. 공백이 없도록 입력해주세요");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
유저 생성 API

## #️⃣연관된 이슈
#8 

## 📝작업 내용
- null처리를 위해 age Inteager로 변경
- User Dto 생성
- 유저 생성 API ("/users") 생성을 위한 컨트롤러(createUser) 및 서비스(createUser) 