### PR TITLE
Feat: User UPDATE API

### DIFF
--- a/src/main/java/intership/test/domain/user/controller/UserController.java
+++ b/src/main/java/intership/test/domain/user/controller/UserController.java
@@ -1,36 +1,36 @@
 package intership.test.domain.user.controller;
 
 import intership.test.domain.user.dto.UserCreate;
-import intership.test.domain.user.dto.UserMapper;
-import intership.test.domain.user.entity.User;
-import intership.test.domain.user.exception.InformationMissing;
+import intership.test.domain.user.dto.UserUpdate;
 import intership.test.domain.user.service.UserService;
-import io.swagger.v3.core.util.Json;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.Response;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.http.HttpResponse;
 import java.util.List;
 
 @RestController
 @RequestMapping(value = "/users")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "User API", description = "유저 관련 API")
 public class UserController {
 
     private final UserService userService;
 
     //C
     @PostMapping("/")
-    public ResponseEntity<String> createUser(@Validated UserCreate userCreate, BindingResult bindingResult){
+    @Operation(summary = "User 생성 API", description = "새로운 유저를 생성하는 API입니다.")
+    public ResponseEntity<String> createUser(
+            @Validated UserCreate userCreate,
+            BindingResult bindingResult
+    ){
 
         if(bindingResult.hasErrors()){
             StringBuilder errorMsg = new StringBuilder();
@@ -45,23 +45,40 @@ public class UserController {
     }
 
     //R
-    @GetMapping("/{id}")
-    public ResponseEntity<UserCreate> getOneUser(@RequestParam Long id){
-        UserCreate user = userService.getOneUser(id);
+    @GetMapping("/{user_id}")
+    @Operation(summary = "단일 User 불러오기 API", description = "특정 유저의 정보를 불러오는 API입니다.")
+    public ResponseEntity<UserCreate> getOneUser(
+            @PathVariable Long user_id
+    ){
+        UserCreate user = userService.getOneUser(user_id);
         return ResponseEntity.status(HttpStatus.OK).body(user);
     }
 
     @GetMapping("/")
+    @Operation(summary = "전체 User 불러오기 API", description = "전체 유저의 정보를 불러오는 API입니다.")
     public ResponseEntity<List<UserCreate>> getAllUser(){
         List<UserCreate> allUser = userService.getAllUser();
         return ResponseEntity.status(HttpStatus.OK).body(allUser);
     }
 
-    @DeleteMapping("/{id}")
+    //U
+    @PatchMapping("/{user_id}")
+    @Operation(summary = "User 변경 API", description = "기존 유저의 이름 / 나이를 변경할 수 있는 API입니다.")
+    public ResponseEntity<String> updateUser(
+            @PathVariable Long user_id,
+            @RequestBody UserUpdate userUpdate
+            ){
+        userService.updateUser(user_id, userUpdate);
+        return ResponseEntity.ok("유저 정보 변경을 완료하였습니다.");
+    }
+
+    //D
+    @DeleteMapping("/{user_id}")
+    @Operation(summary = "User 삭제 API", description = "유저를 DB에서 삭제하는 API입니다.")
     public ResponseEntity<String> deleteUser(
-            @RequestParam Long id
+            @PathVariable Long user_id
     ){
-        userService.deleteUser(id);
+        userService.deleteUser(user_id);
         return ResponseEntity.ok("유저 삭제를 완료하였습니다.");
     }
 }

--- a/src/main/java/intership/test/domain/user/dto/UserUpdate.java
+++ b/src/main/java/intership/test/domain/user/dto/UserUpdate.java
@@ -1,0 +1,30 @@
+package intership.test.domain.user.dto;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserUpdate {
+    @NotNull(message = "아이디를 입력하지 않았습니다.")
+    private Long id;
+
+    @Nullable
+    private String name;
+
+    @Nullable
+    private Integer age;
+
+    @Builder
+    public UserUpdate(Long id, String name, Integer age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+}

--- a/src/main/java/intership/test/domain/user/entity/User.java
+++ b/src/main/java/intership/test/domain/user/entity/User.java
@@ -9,7 +9,12 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static java.sql.Timestamp.*;
 
 @Entity
 @Getter
@@ -26,11 +31,11 @@ public class User {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
-    private Date createdAt;
+    private Timestamp createdAt;
 
     @Column(name = "modified_at")
     @UpdateTimestamp
-    private Date modifiedAt;
+    private Timestamp modifiedAt;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Likes> likes;
@@ -42,7 +47,7 @@ public class User {
     private List<Comment> comments;
 
     @Builder
-    public User(Long id, String name, Integer age, Date createdAt, Date modifiedAt, List<Likes> likes, List<Board> boards, List<Comment> comments) {
+    public User(Long id, String name, Integer age, Timestamp createdAt, Timestamp modifiedAt, List<Likes> likes, List<Board> boards, List<Comment> comments) {
         this.id = id;
         this.name = name;
         this.age = age;
@@ -51,5 +56,14 @@ public class User {
         this.likes = likes;
         this.boards = boards;
         this.comments = comments;
+    }
+
+    public void updateUser(String name, Integer age){
+        if (name != null) {
+            this.name = name;
+        }
+        if (age != null) {
+            this.age = age;
+        }
     }
 }

--- a/src/main/java/intership/test/domain/user/exception/IdChangeNotAllowed.java
+++ b/src/main/java/intership/test/domain/user/exception/IdChangeNotAllowed.java
@@ -1,0 +1,10 @@
+package intership.test.domain.user.exception;
+
+import intership.test.exception.CustomException;
+import intership.test.exception.ErrorCode;
+
+public class IdChangeNotAllowed extends CustomException {
+    public IdChangeNotAllowed(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/intership/test/domain/user/exception/RequiredInformationMissing.java
+++ b/src/main/java/intership/test/domain/user/exception/RequiredInformationMissing.java
@@ -3,8 +3,8 @@ package intership.test.domain.user.exception;
 import intership.test.exception.CustomException;
 import intership.test.exception.ErrorCode;
 
-public class InformationMissing extends CustomException {
-    public InformationMissing(ErrorCode errorCode){
+public class RequiredInformationMissing extends CustomException {
+    public RequiredInformationMissing(ErrorCode errorCode){
         super(errorCode);
     }
 }

--- a/src/main/java/intership/test/domain/user/service/UserService.java
+++ b/src/main/java/intership/test/domain/user/service/UserService.java
@@ -2,7 +2,9 @@ package intership.test.domain.user.service;
 
 import intership.test.domain.user.dto.UserCreate;
 import intership.test.domain.user.dto.UserMapper;
+import intership.test.domain.user.dto.UserUpdate;
 import intership.test.domain.user.entity.User;
+import intership.test.domain.user.exception.IdChangeNotAllowed;
 import intership.test.domain.user.exception.UserAlreadExist;
 import intership.test.domain.user.exception.UserNotFound;
 import intership.test.domain.user.repository.UserRepository;
@@ -58,6 +60,16 @@ public class UserService {
     }
 
     //U
+    @Transactional
+    public void updateUser(Long id, UserUpdate userUpdate){
+        if(id!=userUpdate.getId()) throw new IdChangeNotAllowed(ErrorCode.ID_CHANGE_NOT_ALLOWED);
+        User user = userRepository.findById(id).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
+
+        user.updateUser(userUpdate.getName(), userUpdate.getAge());
+        userRepository.save(user);
+
+        log.info("수정된 정보 : id={}, name={}, age={}", userUpdate.getId(), userUpdate.getName(), userUpdate.getAge());
+    }
 
     //D
     @Transactional

--- a/src/main/java/intership/test/exception/ErrorCode.java
+++ b/src/main/java/intership/test/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     //User
     USER_NOT_FOUND(BAD_REQUEST, "존재하지 않는 유저입니다, id를 다시 한 번 확인해주세요"),
     USER_ALREADY_EXIST(BAD_REQUEST, "이미 사용중인 아이디 입니다, 다른 아이디로 시도해주세요"),
-    REQUIRED_INFORMATION_MISSING(BAD_REQUEST, "필수 입력값이 입력되지 않았습니다. 공백이 없도록 입력해주세요");
+    REQUIRED_INFORMATION_MISSING(BAD_REQUEST, "필수 입력값이 입력되지 않았습니다. 공백이 없도록 입력해주세요"),
+    ID_CHANGE_NOT_ALLOWED(BAD_REQUEST, "아이디를 변경할 수 없습니다. 다시 한 번 확인해주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
유저 정보(이름/나이) 업데이트 용 API

## #️⃣연관된 이슈
#13 

## 📝작업 내용
- 유저 수정하기 API ("/users/{user_id}") 생성을 위한 컨트롤러 및 서비스 (updateUser)
- 수정 기능을 구현하기 위한 entity method (updateUser) 
- 수정 기능을 위한 dto (UserUpdate) 생성
- 아이디 동일 여부 및 예외처리