### PR TITLE
Feat: BOARD CREATE API

### DIFF
--- a/src/main/java/intership/test/domain/board/controller/BoardController.java
+++ b/src/main/java/intership/test/domain/board/controller/BoardController.java
@@ -1,0 +1,45 @@
+package intership.test.domain.board.controller;
+
+import intership.test.domain.board.dto.BoardCreate;
+import intership.test.domain.board.service.BoardService;
+import intership.test.domain.user.dto.UserCreate;
+import intership.test.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/board")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Board API", description = "게시판 관련 API")
+public class BoardController {
+    private final BoardService boardService;
+
+    //C
+    @PostMapping("")
+    @Operation(summary = "게시물 생성 API", description = "새로운 게시물을 생성하는 API입니다.")
+    public ResponseEntity<String> createBoard(
+            @Validated BoardCreate boardCreate,
+            BindingResult bindingResult
+    ){
+        if(bindingResult.hasErrors()){
+            StringBuilder errorMsg = new StringBuilder();
+            bindingResult.getFieldErrors().forEach(error -> {
+                errorMsg.append(error.getField()).append(": ").append(error.getDefaultMessage()).append("\n");
+            });
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMsg.toString());
+        }
+
+        boardService.createBoard(boardCreate);
+        return ResponseEntity.ok("게시물 생성을 완료하였습니다.");
+    }
+}

--- a/src/main/java/intership/test/domain/board/dto/BoardCreate.java
+++ b/src/main/java/intership/test/domain/board/dto/BoardCreate.java
@@ -1,0 +1,24 @@
+package intership.test.domain.board.dto;
+
+import intership.test.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardCreate {
+    @NotNull(message = "작성자는 공백이 될 수 없습니다.")
+    private Long user_id;
+    @NotNull(message = "제목을 입력하지 않았습니다.")
+    private String title;
+    @NotNull(message = "내용을 입력하지 않았습니다.")
+    private String content;
+
+    @Builder
+    public BoardCreate(Long user_id, String title, String content) {
+        this.user_id = user_id;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/intership/test/domain/board/dto/BoardMapper.java
+++ b/src/main/java/intership/test/domain/board/dto/BoardMapper.java
@@ -1,0 +1,18 @@
+package intership.test.domain.board.dto;
+
+import intership.test.domain.board.entity.Board;
+import intership.test.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardMapper {
+    public static Board toBoard(BoardCreate boardCreate, User user){
+        return Board
+                .builder()
+                .user(user)
+                .title(boardCreate.getTitle())
+                .content(boardCreate.getContent())
+                .build();
+    }
+}

--- a/src/main/java/intership/test/domain/board/entity/Board.java
+++ b/src/main/java/intership/test/domain/board/entity/Board.java
@@ -9,35 +9,35 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.List;
 
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board {
     @Id
     @GeneratedValue
     @Column(name = "board_id")
     private Long id;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @Column(nullable = false)
     private String title;
-
     @Column(columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
-    private Date createdAt;
+    private Timestamp createdAt;
 
     @Column(name = "modified_at")
     @UpdateTimestamp
-    private Date modifiedAt;
+    private Timestamp modifiedAt;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
     @OrderBy("id asc")
@@ -45,4 +45,23 @@ public class Board {
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
     private List<Likes> likes;
+
+    @Builder
+    public Board(Long id,
+                 String title,
+                 String content,
+                 Timestamp createdAt,
+                 Timestamp modifiedAt,
+                 User user,
+                 List<Comment> comments,
+                 List<Likes> likes) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.user = user;
+        this.comments = comments;
+        this.likes = likes;
+    }
 }

--- a/src/main/java/intership/test/domain/board/repository/BoardRepository.java
+++ b/src/main/java/intership/test/domain/board/repository/BoardRepository.java
@@ -1,0 +1,12 @@
+package intership.test.domain.board.repository;
+
+import intership.test.domain.board.entity.Board;
+import intership.test.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/intership/test/domain/board/service/BoardService.java
+++ b/src/main/java/intership/test/domain/board/service/BoardService.java
@@ -1,0 +1,32 @@
+package intership.test.domain.board.service;
+
+import intership.test.domain.board.dto.BoardCreate;
+import intership.test.domain.board.dto.BoardMapper;
+import intership.test.domain.board.entity.Board;
+import intership.test.domain.board.repository.BoardRepository;
+import intership.test.domain.user.entity.User;
+import intership.test.domain.user.exception.UserNotFound;
+import intership.test.domain.user.repository.UserRepository;
+import intership.test.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public void createBoard(BoardCreate boardCreate){
+        User user = userRepository.findById(boardCreate.getUser_id()).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
+        Board board = BoardMapper.toBoard(boardCreate, user);
+        boardRepository.save(board);
+
+        log.info("생성된 게시물 관련 정보입니다. 게시물 id : {} 작성자 : {}, 제목 : {}", board.getId(), user.getName(), board.getTitle());
+    }
+}

--- a/src/main/java/intership/test/domain/like/entity/Likes.java
+++ b/src/main/java/intership/test/domain/like/entity/Likes.java
@@ -7,8 +7,8 @@ import lombok.*;
 
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Likes {
     @Id
     @GeneratedValue

--- a/src/main/java/intership/test/domain/user/controller/UserController.java
+++ b/src/main/java/intership/test/domain/user/controller/UserController.java
@@ -31,7 +31,6 @@ public class UserController {
             @Validated UserCreate userCreate,
             BindingResult bindingResult
     ){
-
         if(bindingResult.hasErrors()){
             StringBuilder errorMsg = new StringBuilder();
             bindingResult.getFieldErrors().forEach(error -> {


### PR DESCRIPTION
게시물 업로드 용 API

## #️⃣연관된 이슈
#15 

## 📝작업 내용
- Board Entity 수정
- repository 생성
- 보드 생성하기 API ("/board") 생성을 위한 컨트롤러 및 서비스 (createBoard)
- 생성을 위한 dto 및 mapper
