### PR TITLE
Feat : COMMENT CREATE API

### DIFF
--- a/src/main/java/intership/test/domain/board/entity/Board.java
+++ b/src/main/java/intership/test/domain/board/entity/Board.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     @Column(name = "board_id")
     private Long id;
 

--- a/src/main/java/intership/test/domain/comment/controller/CommentController.java
+++ b/src/main/java/intership/test/domain/comment/controller/CommentController.java
@@ -1,0 +1,46 @@
+package intership.test.domain.comment.controller;
+
+import intership.test.domain.board.dto.BoardCreate;
+import intership.test.domain.comment.dto.CommentCreate;
+import intership.test.domain.comment.dto.CommentMapping;
+import intership.test.domain.comment.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/comment")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Comment API", description = "댓글 관련 API")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    //C
+    @PostMapping("")
+    @Operation(summary = "댓글 생성 API", description = "새로운 댓글을 생성하는 API입니다.")
+    public ResponseEntity<String> createComment(
+            @Validated CommentCreate commentCreate,
+            BindingResult bindingResult
+    ){
+        if(bindingResult.hasErrors()){
+            StringBuilder errorMsg = new StringBuilder();
+            bindingResult.getFieldErrors().forEach(error -> {
+                errorMsg.append(error.getField()).append(": ").append(error.getDefaultMessage()).append("\n");
+            });
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMsg.toString());
+        }
+
+        commentService.createComment(commentCreate);
+        return ResponseEntity.ok("댓글 생성을 완료하였습니다.");
+    }
+}

--- a/src/main/java/intership/test/domain/comment/dto/CommentCreate.java
+++ b/src/main/java/intership/test/domain/comment/dto/CommentCreate.java
@@ -1,0 +1,28 @@
+package intership.test.domain.comment.dto;
+
+import intership.test.domain.board.entity.Board;
+import intership.test.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentCreate {
+
+    @NotNull(message = "내용을 입력하지 않았습니다.")
+    private String content;
+    private Long user_id;
+    private Long board_idx;
+
+    @Builder
+
+    public CommentCreate(String content, Long user_id, Long board_idx) {
+        this.content = content;
+        this.user_id = user_id;
+        this.board_idx = board_idx;
+    }
+}

--- a/src/main/java/intership/test/domain/comment/dto/CommentMapping.java
+++ b/src/main/java/intership/test/domain/comment/dto/CommentMapping.java
@@ -1,0 +1,16 @@
+package intership.test.domain.comment.dto;
+
+import intership.test.domain.board.entity.Board;
+import intership.test.domain.comment.entity.Comment;
+import intership.test.domain.user.entity.User;
+
+public class CommentMapping {
+    public static Comment toComment(CommentCreate commentCreate, User user, Board board){
+        return Comment
+                .builder()
+                .content(commentCreate.getContent())
+                .user(user)
+                .board(board)
+                .build();
+    }
+}

--- a/src/main/java/intership/test/domain/comment/entity/Comment.java
+++ b/src/main/java/intership/test/domain/comment/entity/Comment.java
@@ -11,11 +11,10 @@ import java.sql.Date;
 
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
     @Column(name = "comment_id")
     private Long id;
 
@@ -37,4 +36,15 @@ public class Comment {
     @ManyToOne
     @JoinColumn(name = "board_id")
     private Board board;
+
+    @Builder
+
+    public Comment(Long id, String content, Date createdAt, Date modifiedAt, User user, Board board) {
+        this.id = id;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.user = user;
+        this.board = board;
+    }
 }

--- a/src/main/java/intership/test/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/intership/test/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package intership.test.domain.comment.repository;
+
+import intership.test.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/intership/test/domain/comment/service/CommentService.java
+++ b/src/main/java/intership/test/domain/comment/service/CommentService.java
@@ -1,0 +1,38 @@
+package intership.test.domain.comment.service;
+
+import intership.test.domain.board.entity.Board;
+import intership.test.domain.board.exception.BoardNotFound;
+import intership.test.domain.board.repository.BoardRepository;
+import intership.test.domain.comment.dto.CommentCreate;
+import intership.test.domain.comment.dto.CommentMapping;
+import intership.test.domain.comment.entity.Comment;
+import intership.test.domain.comment.repository.CommentRepository;
+import intership.test.domain.user.entity.User;
+import intership.test.domain.user.exception.UserNotFound;
+import intership.test.domain.user.repository.UserRepository;
+import intership.test.exception.ErrorCode;
+import jakarta.persistence.Temporal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void createComment(CommentCreate commentCreate){
+        User user = userRepository.findById(commentCreate.getUser_id()).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
+        Board board = boardRepository.findById(commentCreate.getBoard_idx()).orElseThrow(() -> new BoardNotFound(ErrorCode.BOARD_NOT_FOUND));
+
+        Comment comment = CommentMapping.toComment(commentCreate, user, board);
+
+        commentRepository.save(comment);
+    }
+}


### PR DESCRIPTION
댓글 생성 API 생성

## #️⃣연관된 이슈
#26 

## 📝작업 내용
- repository 및 dto todtjd
- 댓글 생성하기 API (POST "/comment") 생성을 위한 컨트롤러 및 서비스 (createBoard)