### PR TITLE
Feat : BOARD DELETE API

### DIFF
--- a/src/main/java/intership/test/domain/board/controller/BoardController.java
+++ b/src/main/java/intership/test/domain/board/controller/BoardController.java
@@ -67,4 +67,12 @@ public class BoardController {
         boardService.updateBoard(boardUpdate, board_idx);
         return ResponseEntity.ok("게시물 업데이트를 완료하였습니다.");
     }
+
+    //D
+    @DeleteMapping("/{board_id}")
+    @Operation(summary = "게시물 삭제 API", description = "게시물을 삭제하는 API입니다.")
+    public ResponseEntity<String> deleteBoard(@PathVariable Long board_id){
+        boardService.deleteBoard(board_id);
+        return ResponseEntity.ok("게시물 삭제를 완료하였습니다.");
+    }
 }

--- a/src/main/java/intership/test/domain/board/service/BoardService.java
+++ b/src/main/java/intership/test/domain/board/service/BoardService.java
@@ -60,5 +60,15 @@ public class BoardService {
         boardRepository.save(board);
     }
 
+    //D
+    @Transactional
+    public void deleteBoard(Long idx){
+        Board board = boardRepository.findById(idx).orElseThrow(() -> new BoardNotFound(ErrorCode.BOARD_NOT_FOUND));
+
+        log.info("삭제된 게시물 : {}",board.getId());
+
+        boardRepository.deleteById(idx);
+    }
+
 
 }

--- a/src/main/java/intership/test/domain/user/service/UserService.java
+++ b/src/main/java/intership/test/domain/user/service/UserService.java
@@ -76,8 +76,9 @@ public class UserService {
     public void deleteUser(Long id){
         User user = userRepository.findById(id).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
 
+        log.info("삭제된 유저 : {}", user.getId());
+
         userRepository.deleteById(id);
 
-        log.info("삭제된 유저 : {}", user.getId());
     }
 }


### PR DESCRIPTION
게시물 삭제 API 생성

## #️⃣연관된 이슈
#28 

## 📝작업 내용
- 게시물 삭제 (DELETE /board/{board_idx})
- CASCADE.REMOVE 동작에 문제 없음 확인 