### PR TITLE
Bug : User Delete시 board 삭제 해결

### DIFF
--- a/src/main/java/intership/test/domain/board/dto/BoardMapper.java
+++ b/src/main/java/intership/test/domain/board/dto/BoardMapper.java
@@ -45,7 +45,7 @@ public class BoardMapper {
                 .title(board.getTitle())
                 .userName(board.getUser().getName())
                 .content(board.getContent())
-                .like_num(board.getUsers().size())
+                .like_num(board.getLike_cnt())
                 .comment(commentGets)
                 .create_at(board.getCreatedAt())
                 .build();

--- a/src/main/java/intership/test/domain/board/entity/Board.java
+++ b/src/main/java/intership/test/domain/board/entity/Board.java
@@ -1,14 +1,15 @@
 package intership.test.domain.board.entity;
 
 import intership.test.domain.comment.entity.Comment;
-import intership.test.domain.like.entity.Likes;
 import intership.test.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +19,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "board_id")
     private Long id;
 
@@ -28,9 +29,12 @@ public class Board {
 
     @Column(nullable = false)
     private String title;
+
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    @Column
+    private Integer like_cnt = 0;
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
     private Timestamp createdAt;
@@ -38,7 +42,6 @@ public class Board {
     @Column(name = "modified_at")
     @UpdateTimestamp
     private Timestamp modifiedAt;
-
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
     @OrderBy("id asc")
@@ -49,11 +52,12 @@ public class Board {
     List<User> users = new ArrayList<>();
 
     @Builder
-    public Board(Long id, User user, String title, String content, Timestamp createdAt, Timestamp modifiedAt, List<Comment> comments, List<User> users) {
+    public Board(Long id, User user, String title, String content, int like_cnt, Timestamp createdAt, Timestamp modifiedAt, List<Comment> comments, List<User> users) {
         this.id = id;
         this.user = user;
         this.title = title;
         this.content = content;
+        this.like_cnt = like_cnt;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
         this.comments = comments;
@@ -62,6 +66,12 @@ public class Board {
 
     public void updateBoardLike(User user){
         this.users.add(user);
+        this.like_cnt += 1;
+    }
+
+    public void updateBoardAfterDeleteUser(List<User> users){
+        this.users = users;
+        this.like_cnt = users.size();
     }
 
     public void updateBoard(User user, String title, String content){

--- a/src/main/java/intership/test/domain/board/repository/BoardRepository.java
+++ b/src/main/java/intership/test/domain/board/repository/BoardRepository.java
@@ -1,12 +1,8 @@
 package intership.test.domain.board.repository;
 
 import intership.test.domain.board.entity.Board;
-import intership.test.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {

--- a/src/main/java/intership/test/domain/board/service/BoardLikeService.java
+++ b/src/main/java/intership/test/domain/board/service/BoardLikeService.java
@@ -1,7 +1,5 @@
 package intership.test.domain.board.service;
 
-import intership.test.domain.board.dto.BoardCreate;
-import intership.test.domain.board.dto.BoardMapper;
 import intership.test.domain.board.entity.Board;
 import intership.test.domain.board.exception.BoardNotFound;
 import intership.test.domain.board.repository.BoardRepository;
@@ -13,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -30,6 +30,18 @@ public class BoardLikeService {
         board.updateBoardLike(user);
 
         log.info("게시물 관련 정보입니다. 게시물 id : {} 좋아요 수 : {}", board.getId(), board.getUsers().size());
+    }
+
+    @Transactional
+    public void deleteBoardLike(Long id){
+        User user = userRepository.findById(id).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
+
+        List<Board> boards = user.getBoard_like();
+        for (Board board : boards) {
+            List<User> users = board.getUsers();
+            users.remove(user);
+            board.updateBoardAfterDeleteUser(users);
+        }
     }
 
 }

--- a/src/main/java/intership/test/domain/comment/controller/CommentController.java
+++ b/src/main/java/intership/test/domain/comment/controller/CommentController.java
@@ -1,8 +1,6 @@
 package intership.test.domain.comment.controller;
 
-import intership.test.domain.board.dto.BoardCreate;
 import intership.test.domain.comment.dto.CommentCreate;
-import intership.test.domain.comment.dto.CommentMapping;
 import intership.test.domain.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/intership/test/domain/comment/dto/CommentCreate.java
+++ b/src/main/java/intership/test/domain/comment/dto/CommentCreate.java
@@ -1,7 +1,5 @@
 package intership.test.domain.comment.dto;
 
-import intership.test.domain.board.entity.Board;
-import intership.test.domain.user.entity.User;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/intership/test/domain/comment/dto/CommentGet.java
+++ b/src/main/java/intership/test/domain/comment/dto/CommentGet.java
@@ -1,6 +1,5 @@
 package intership.test.domain.comment.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/intership/test/domain/comment/entity/Comment.java
+++ b/src/main/java/intership/test/domain/comment/entity/Comment.java
@@ -1,14 +1,15 @@
 package intership.test.domain.comment.entity;
 
-import intership.test.domain.user.entity.User;
 import intership.test.domain.board.entity.Board;
+import intership.test.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import java.sql.Date;
-import java.sql.Time;
 import java.sql.Timestamp;
 
 @Entity
@@ -16,7 +17,7 @@ import java.sql.Timestamp;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
     private Long id;
 

--- a/src/main/java/intership/test/domain/comment/service/CommentService.java
+++ b/src/main/java/intership/test/domain/comment/service/CommentService.java
@@ -11,10 +11,8 @@ import intership.test.domain.user.entity.User;
 import intership.test.domain.user.exception.UserNotFound;
 import intership.test.domain.user.repository.UserRepository;
 import intership.test.exception.ErrorCode;
-import jakarta.persistence.Temporal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/intership/test/domain/user/dto/UserUpdate.java
+++ b/src/main/java/intership/test/domain/user/dto/UserUpdate.java
@@ -1,7 +1,6 @@
 package intership.test.domain.user.dto;
 
 import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/intership/test/domain/user/entity/User.java
+++ b/src/main/java/intership/test/domain/user/entity/User.java
@@ -2,7 +2,6 @@ package intership.test.domain.user.entity;
 
 import intership.test.domain.board.entity.Board;
 import intership.test.domain.comment.entity.Comment;
-import intership.test.domain.like.entity.Likes;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,8 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -27,6 +26,9 @@ public class User {
 
     private Integer age;
 
+    @ManyToMany(mappedBy = "users")
+    private List<Board> board_like;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
     private Timestamp createdAt;
@@ -35,43 +37,28 @@ public class User {
     @UpdateTimestamp
     private Timestamp modifiedAt;
 
-    //ON DELETE SET DEFAULT
-    @ManyToMany(mappedBy = "users", cascade = CascadeType.MERGE)
-    List<Board> boards_like = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user", cascade = {CascadeType.MERGE, CascadeType.REMOVE})
-    private List<Likes> likes;
-
-    @OneToMany(mappedBy = "user", cascade = {CascadeType.MERGE, CascadeType.REMOVE})
+    @OneToMany(mappedBy = "user", cascade = CascadeType.MERGE)
     private List<Board> boards;
 
     //ON DELETE SET DEFAULT
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Comment> comments;
 
-    public User(Long id, String name, Integer age, Timestamp createdAt, Timestamp modifiedAt, List<Board> boards_like, List<Likes> likes, List<Board> boards, List<Comment> comments) {
+    @Builder
+    public User(Long id, String name, Integer age, Timestamp createdAt, Timestamp modifiedAt, List<Board> boards, List<Comment> comments) {
         this.id = id;
         this.name = name;
         this.age = age;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
-        this.boards_like = boards_like;
-        this.likes = likes;
         this.boards = boards;
         this.comments = comments;
     }
 
-    @Builder
-    public User(Long id, String name, Integer age, Timestamp createdAt, Timestamp modifiedAt, List<Likes> likes, List<Board> boards, List<Comment> comments) {
-        this.id = id;
-        this.name = name;
-        this.age = age;
-        this.createdAt = createdAt;
-        this.modifiedAt = modifiedAt;
-        this.likes = likes;
-        this.boards = boards;
-        this.comments = comments;
-    }
+
+
+
+
 
     public void updateUser(String name, Integer age){
         if (name != null) {

--- a/src/main/java/intership/test/domain/user/service/UserService.java
+++ b/src/main/java/intership/test/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package intership.test.domain.user.service;
 
+import intership.test.domain.board.service.BoardLikeService;
 import intership.test.domain.user.dto.UserCreate;
 import intership.test.domain.user.dto.UserMapper;
 import intership.test.domain.user.dto.UserUpdate;
@@ -24,6 +25,7 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final BoardLikeService boardLikeService;
 
     //C
     @Transactional
@@ -75,6 +77,8 @@ public class UserService {
     @Transactional
     public void deleteUser(Long id){
         User user = userRepository.findById(id).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
+
+        boardLikeService.deleteBoardLike(id);
 
         log.info("삭제된 유저 : {}", user.getId());
 


### PR DESCRIPTION
유저를 삭제할 시 좋아요를 누른 타 유저의 게시물이 사라지는 부분 해결

## #️⃣연관된 이슈
#31 

## 📝작업 내용
- 보드 및 유저 엔티티 다대다 매핑 시 CASCADE 조건 삭제
- 유저 삭제 시 보드의 User list와 User count를 수정하는 것으로 방식 변경
- 사용하지 않는 import문 제거