### PR TITLE
Feat : Comment Delete API

### DIFF
--- a/src/main/java/intership/test/domain/comment/controller/CommentController.java
+++ b/src/main/java/intership/test/domain/comment/controller/CommentController.java
@@ -60,4 +60,12 @@ public class CommentController {
     }
 
     //D
+    @DeleteMapping("/{comment_idx}")
+    @Operation(summary = "댓글 삭제 API", description = "댓글을 삭제하는 API입니다.")
+    public ResponseEntity<String> deleteComment(@PathVariable Long comment_idx){
+        commentService.deleteComment(comment_idx);
+
+        return ResponseEntity.ok("댓글 삭제를 완료하였습니다.");
+    }
+
 }

--- a/src/main/java/intership/test/domain/comment/service/CommentService.java
+++ b/src/main/java/intership/test/domain/comment/service/CommentService.java
@@ -59,5 +59,14 @@ public class CommentService {
 
         commentRepository.save(comment);
     }
+
     //D
+    @Transactional
+    public void deleteComment(Long comment_id){
+        Comment comment = commentRepository.findById(comment_id).orElseThrow(() -> new CommentNotFound(ErrorCode.COMMENT_NOT_FOUND));
+
+        log.info("삭제할 댓글 정보 : id = {}, content = {}", comment.getId(), comment.getContent());
+
+        commentRepository.deleteById(comment_id);
+    }
 }


### PR DESCRIPTION
댓글 삭제 관련 API 생성

## #️⃣연관된 이슈
#39 

## 📝작업 내용
- 댓글 삭제 (DELETE /comment/{comment_idx})를 위한 컨트롤러 및 서비스 생성 (deleteComment)