### PR TITLE
Fix : 유저 삭제 변경

### DIFF
--- a/src/main/java/intership/test/domain/board/entity/Board.java
+++ b/src/main/java/intership/test/domain/board/entity/Board.java
@@ -79,4 +79,8 @@ public class Board {
         if(title != null) this.title = title;
         if(content != null) this.content = content;
     }
+
+    public void writerDelete(User user){
+        this.user = user;
+    }
 }

--- a/src/main/java/intership/test/domain/comment/entity/Comment.java
+++ b/src/main/java/intership/test/domain/comment/entity/Comment.java
@@ -61,4 +61,8 @@ public class Comment {
         if(user != null) this.user = user;
         if(content != null) this.content = content;
     }
+
+    public void writerDelete(User user){
+        this.user = user;
+    }
 }

--- a/src/main/java/intership/test/domain/user/entity/User.java
+++ b/src/main/java/intership/test/domain/user/entity/User.java
@@ -37,11 +37,11 @@ public class User {
     @UpdateTimestamp
     private Timestamp modifiedAt;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.MERGE)
+    @OneToMany(mappedBy = "user")
     private List<Board> boards;
 
     //ON DELETE SET DEFAULT
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "user")
     private List<Comment> comments;
 
     @Builder

--- a/src/main/java/intership/test/domain/user/service/UserService.java
+++ b/src/main/java/intership/test/domain/user/service/UserService.java
@@ -1,6 +1,10 @@
 package intership.test.domain.user.service;
 
+import intership.test.domain.board.entity.Board;
+import intership.test.domain.board.repository.BoardRepository;
 import intership.test.domain.board.service.BoardLikeService;
+import intership.test.domain.comment.entity.Comment;
+import intership.test.domain.comment.repository.CommentRepository;
 import intership.test.domain.user.dto.UserCreate;
 import intership.test.domain.user.dto.UserMapper;
 import intership.test.domain.user.dto.UserUpdate;
@@ -26,6 +30,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final BoardLikeService boardLikeService;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public void createInitialUser() {
@@ -89,6 +95,18 @@ public class UserService {
     @Transactional
     public void deleteUser(Long id){
         User user = userRepository.findById(id).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
+
+        User default_user = userRepository.findById(0L).orElseThrow(() -> new UserNotFound(ErrorCode.USER_NOT_FOUND));
+
+        for (Board board : user.getBoards()) {
+            board.writerDelete(default_user);
+            boardRepository.save(board);
+        }
+
+        for (Comment comment : user.getComments()) {
+            comment.writerDelete(default_user);
+            commentRepository.save(comment);
+        }
 
         boardLikeService.deleteBoardLike(id);
 


### PR DESCRIPTION
유저 삭제 시 default user를 지칭할 수 있도록 on delete set default 기능 구현

## #️⃣연관된 이슈
#45 

## 📝작업 내용
- 각 엔티티에 유저가 삭제되었을 때 업데이트 할 수 있는 writerDelete생성
- 유저와 임시로 연결되어있던 CASCADE.REMOVE 삭제
- UserService 중 deleteUser 수정